### PR TITLE
Fixing that team name bugs at halftime

### DIFF
--- a/public/huds/default/index.js
+++ b/public/huds/default/index.js
@@ -284,10 +284,10 @@ function updatePage(data) {
         teams.right.players = right.players || null;
 
         $("#match_one_info")
-            .removeClass("ct t")
+            .removeClass("ct-color t-color")
             .addClass(test_player2.team.toLowerCase());
         $("#match_two_info")
-            .removeClass("ct t")
+            .removeClass("ct-color t-color")
             .addClass(test_player2.team.toLowerCase() != "ct"
                 ? "ct"
                 : "t");


### PR DESCRIPTION
The team names bugs everytime its halftime or after a knife round, because the class we add to it is; ct-color/t-color . But the class we remove is only t/ct. Fixing this to remove the original class we ad onto it